### PR TITLE
Better reprovisionning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ All configuration can be updated by re-running the role, except for the [blobsto
 
 ## Requirements
 
+- Minimum ansible version 2.2 (see meta/main.yml)
 - This has only been tested on CentOS 7 + Ubuntu 16.04 (Xenial)
 - Oracle Java 8 (mandatory)
 - Apache HTTPD (optional, used to setup a SSL reverse-proxy)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,7 +25,6 @@
     name: httpd.service
     state: reloaded
     enabled: yes
-    no_block: yes
 
 - name: wait-for-httpd
   wait_for:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,11 @@
     daemon-reload: yes
     name: nexus.service
 
+- name: nexus-service-restart
+  systemd:
+    name: nexus.service
+    state: restarted
+
 - name: nexus-service-stop
   systemd:
     name: nexus.service

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,33 @@
+---
+- name: systemd-reload
+  systemd:
+    daemon-reload: yes
+
+- name: nexus-service-stop
+  systemd:
+    name: nexus.service
+    state: stopped
+  when: nexus_systemd_service_file.stat.exists
+
+- name: wait-for-nexus
+  wait_for:
+    path: "{{ nexus_data_dir }}/log/nexus.log"
+    search_regex: "Started Sonatype Nexus OSS .*"
+    timeout: 1800
+
+- name: wait-for-nexus-port
+  wait_for:
+    port: "{{ nexus_default_port }}"
+    delay: 5
+
+- name: apache-service-reload
+  systemd:
+    name: httpd.service
+    state: reloaded
+    enabled: yes
+    no_block: yes
+
+- name: wait-for-httpd
+  wait_for:
+    port: 443
+    delay: 5

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -21,7 +21,7 @@
     port: "{{ nexus_default_port }}"
     delay: 5
 
-- name: apache-service-reload
+- name: httpd-service-reload
   systemd:
     name: httpd.service
     state: reloaded

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: systemd-reload
   systemd:
     daemon-reload: yes
+    name: nexus.service
 
 - name: nexus-service-stop
   systemd:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: license (GPLv3)
 
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
 
   github_branch: master
 

--- a/tasks/httpd_reverse_proxy_config.yml
+++ b/tasks/httpd_reverse_proxy_config.yml
@@ -1,24 +1,31 @@
 ---
 - name: Copy httpd vhost
-  template: src="nexus-vhost.conf" dest="/etc/httpd/conf.d"
+  template:
+    src: "nexus-vhost.conf"
+    dest: "/etc/httpd/conf.d"
+  notify:
+    - httpd-service-reload
+    - wait-for-httpd
 
 - name: Copy SSL certificate file
   copy:
     src: "{{ httpd_ssl_certificate_file }}"
     dest: "/etc/pki/tls/certs"
     mode: 600
+  notify:
+    - httpd-service-reload
+    - wait-for-httpd
 
 - name: Copy SSL certificate key file
   copy:
     src: "{{ httpd_ssl_certificate_key_file }}"
     dest: "/etc/pki/tls/private"
     mode: 600
+  notify:
+    - httpd-service-reload
+    - wait-for-httpd
 
 - name: Setsebool httpd_can_network_connect
   shell: 'setsebool -P httpd_can_network_connect on'
 
-- name: Restart httpd
-  shell: 'systemctl restart httpd.service'
-
-- name: Waiting for httpd to be restarted
-  wait_for: port=443 delay=5
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Check if SystemD service is installed
+  stat:
+    path: /etc/systemd/system/nexus.service
+  register: nexus_systemd_service_file
+
 - include: nexus_purge.yml
   when: ((purge is defined) and (purge | bool))
 

--- a/tasks/nexus-restore.yml
+++ b/tasks/nexus-restore.yml
@@ -1,17 +1,9 @@
 ---
 - name: "Run restoration script"
   shell: "nexus-blob-restore.sh {{ nexus_restore_point }} 2>&1 | tee -a {{ nexus_restore_log }}"
+  notify:
+    - nexus-service-restart
+    - wait-for-nexus
+    - wait-for-nexus-port
 
-- name: Restart systemd service
-  shell: 'systemctl restart nexus.service'
-
-- name: Waiting for Nexus service to be ready...
-  wait_for:
-    path: "{{ nexus_data_dir }}/log/nexus.log"
-    search_regex: "Started Sonatype Nexus OSS .*"
-    timeout: 1800
-
-- name: Waiting for nexus to be ready...
-  wait_for:
-    port: "{{ nexus_default_port }}"
-    delay: 5
+- meta: flush_handlers

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -208,7 +208,6 @@
     name: nexus.service
     enabled: yes
     state: started
-    no_block: yes
   notify:
     - wait-for-nexus
     - wait-for-nexus-port

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -34,11 +34,6 @@
   notify:
     - nexus-service-stop
 
-- name: Check if SystemD service is installed
-  stat:
-    path: /etc/systemd/system/nexus.service
-  register: nexus_systemd_service_file
-
 - meta: flush_handlers
 
 - name: Update symlink nexus-latest

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -4,6 +4,8 @@
     url: "http://download.sonatype.com/nexus/3/{{ nexus_package }}"
     dest: "{{ nexus_download_dir }}/{{ nexus_package }}"
     force: no
+  notify:
+    - nexus-service-stop
 
 - name: Ensure Nexus o/s group exists
   group:
@@ -29,15 +31,15 @@
     creates: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
     force: no
     copy: false
+  notify:
+    - nexus-service-stop
 
 - name: Check if SystemD service is installed
   stat:
     path: /etc/systemd/system/nexus.service
   register: nexus_systemd_service_file
 
-- name: Stop systemd service
-  shell: 'systemctl stop nexus.service'
-  when: nexus_systemd_service_file.stat.exists
+- meta: flush_handlers
 
 - name: Update symlink nexus-latest
   file:
@@ -166,10 +168,8 @@
   template:
     src: "nexus.service"
     dest: "/etc/systemd/system"
-
-# systemd available from ansible 2.2 only
-# - name: Enable nexus service
-#   systemd: name=nexus daemon_reload=yes enabled=yes state=started
+  notify:
+    - systemd-reload
 
 - name: "Register scripts to be deployed"
   set_fact:
@@ -201,25 +201,19 @@
     state: touch
   when: nexus_latest_version.changed and nexus_data_dir_contents.stdout != ""
 
-- name: Reload systemd service configuration
-  shell: 'systemctl daemon-reload'
+- meta: flush_handlers
 
-- name: Enable systemd service
-  shell: 'systemctl enable nexus.service'
+- name: Enable nexus service and make sure it is started
+  systemd:
+    name: nexus.service
+    enabled: yes
+    state: started
+    no_block: yes
+  notify:
+    - wait-for-nexus
+    - wait-for-nexus-port
 
-- name: Restart systemd service
-  shell: 'systemctl restart nexus.service'
-
-- name: Waiting for Nexus service to be ready...
-  wait_for:
-    path: "{{ nexus_data_dir }}/log/nexus.log"
-    search_regex: "Started Sonatype Nexus OSS .*"
-    timeout: 1800
-
-- name: Waiting for nexus to be ready...
-  wait_for:
-    port: "{{ nexus_default_port }}"
-    delay: 5
+- meta: flush_handlers
 
 - name: Chown configuration files from {{ nexus_installation_dir }}/nexus-latest/etc back to root
   file:

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -238,44 +238,28 @@
   when: nexus_data_dir_contents.stdout != ""
   no_log: true
 
+- name: Create directory to hold current groovy scripts for reference
+  file:
+    path: "{{ nexus_data_dir }}/groovy-raw-scripts/current"
+    state: directory
+    owner: root
+    group: root
+
+- name: Upload new scripts
+  synchronize:
+    recursive: yes
+    delete: yes
+    mode: push
+    src: "files/groovy/"
+    dest: "{{ nexus_data_dir }}/groovy-raw-scripts/new/"
+
+- name: Sync new scripts to old and get differences
+  shell: 'rsync -ric {{ nexus_data_dir }}/groovy-raw-scripts/new/ {{ nexus_data_dir }}/groovy-raw-scripts/current/ | cut -d" " -f 2 | sed "s/\.groovy//g"'
+  register: nexus_groovy_files_changed
+  changed_when: false
+
 - include: declare_script_each.yml
-  with_items:
-    - update_admin_password
-    - setup_ldap
-    - setup_anonymous_access
-    - setup_base_url
-    - setup_capability
-    - setup_http_proxy
-    - setup_role
-    - setup_privilege
-    - setup_user
-    - setup_realms
-    - delete_repo
-    - delete_blobstore
-    - create_blobstore
-    - create_repo_maven_proxy
-    - create_repo_maven_group
-    - create_repo_maven_hosted
-    - create_repo_docker_hosted
-    - create_repo_docker_proxy
-    - create_repo_docker_group
-    - create_repo_pypi_hosted
-    - create_repo_pypi_proxy
-    - create_repo_pypi_group
-    - create_repo_raw_hosted
-    - create_repo_raw_proxy
-    - create_repo_raw_group
-    - create_repo_rubygems_hosted
-    - create_repo_rubygems_proxy
-    - create_repo_rubygems_group
-    - create_repo_bower_hosted
-    - create_repo_bower_proxy
-    - create_repo_bower_group
-    - create_repo_npm_hosted
-    - create_repo_npm_proxy
-    - create_repo_npm_group
-    - create_repo_gitlfs_hosted
-    - create_task
+  with_items: "{{ nexus_groovy_files_changed.stdout_lines}}"
 
 - name: "Config nexus-backup shell cron"
   cron:

--- a/tasks/nexus_purge.yml
+++ b/tasks/nexus_purge.yml
@@ -1,4 +1,18 @@
 ---
+- name: Make sure nexus is stopped
+  debug:
+    msg: "trigger nexus stop"
+  changed_when: true
+  notify:
+    - nexus-service-stop
+
+- meta: flush_handlers
+
+- name: "Make sure an other nexus install is not running"
+  service:
+    name: nexus
+    state: stopped
+
 - name: "Purge Nexus"
   file:
     path: "{{ item }}"
@@ -9,12 +23,7 @@
   - "{{ nexus_restore_log }}"
 # - "{{ nexus_backup_dir }}" # Optional
 
-- name: "service stop"
-  service:
-    name: nexus
-    state: stopped
-
-- name: "remove nexus package"
+- name: "remove nexus package if present"
   package:
     name: nexus
     state: absent

--- a/tasks/nexus_purge.yml
+++ b/tasks/nexus_purge.yml
@@ -8,11 +8,6 @@
 
 - meta: flush_handlers
 
-- name: "Make sure an other nexus install is not running"
-  service:
-    name: nexus
-    state: stopped
-
 - name: "Purge Nexus"
   file:
     path: "{{ item }}"


### PR DESCRIPTION
This role already takes into account reprovisionning of nexus. Meanwhile, when you just want to push some provisioning changes (add a repository, change a user password, add a new nexus role....), the nexus server will go down even though it is not always necessary.

Also, groovy scripts will be systematically removed/declared even if they didn't change

The goal of this PR is to strengthen this kind of task by removing unnecessary stop/starts/script updates when you just need to reprovision.