### PR TITLE
- Fixed multiple issues to support the httpd reverse proxy on Ubuntu …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ Header and footer branding, those can contain HTML.
 
 Setup an [SSL Reverse-proxy](https://books.sonatype.com/nexus-book/3.0/reference/install.html#_example_reverse_proxy_ssl_termination_at_base_path), this needs httpd installed. Note : when `httpd_setup_enable` is set to `true`, nexus binds to 127.0.0.1:8081 thus *not* being directly accessible on HTTP port 8081 from an external IP.
 
+    httpd_copy_ssl_files: true  # Default is false
+    # These specifies to the vhost where to find on the remote server file 
+    # system the certificate files.
+    httpd_ssl_cert_file_location: "/etc/pki/tls/certs/wildcard.vm.crt"
+    httpd_ssl_cert_key_location: "/etc/pki/tls/private/wildcard.vm.key"
+
+Use already existing SSL certificates on the server file system for the https reverse proxy
+
+    httpd_default_admin_email: "admin@example.com"
+
+Set httpd default admin email address
+
     ldap_connections: []
 
 [LDAP connection(s)](https://books.sonatype.com/nexus-book/3.0/reference/security.html#ldap) setup, each item goes as follow :
@@ -385,11 +397,12 @@ The java and httpd requirements /can/ be fulfilled with the following galaxy rol
           - jaspersoft
 
   roles:
-    - role: ansiblebit.oracle-java
-      oracle_java_set_as_default: yes
-    - role: geerlingguy.apache
-      apache_create_vhosts: no
-    - role: savoirfairelinux.nexus3-oss
+    - { role: ansiblebit.oracle-java, oracle_java_set_as_default: yes, tags: ['ansiblebit.oracle-java'] }
+    # Debian/Ubuntu only
+    # - { role: geerlingguy.apache, apache_create_vhosts: no, apache_mods_enabled: ["proxy_http.load", "headers.load"], apache_remove_default_vhost: true, tags: ["geerlingguy.apache"] }
+    # RedHat/CentOS only
+    - { role: geerlingguy.apache, apache_create_vhosts: no, apache_remove_default_vhost: true, tags: ["geerlingguy.apache"] }
+    - { role: savoirfairelinux.nexus3-oss, tags: ['savoirfairelinux.nexus3-oss'] }
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,14 @@ nexus_branding_footer: "Last provisionned {{ ansible_date_time.iso8601 }}"
 httpd_setup_enable: false
 httpd_ssl_certificate_file: 'files/nexus.vm.crt'
 httpd_ssl_certificate_key_file: 'files/nexus.vm.key'
+# If httpd_copy_ssl_files is false you need to provide the following variables:
+# - httpd_ssl_cert_file_location
+# - httpd_ssl_cert_key_location
+httpd_copy_ssl_files: true
+# These specifies to the vhost file where to find on the remote file system the certificates files.
+httpd_ssl_cert_file_location: "/etc/pki/tls/certs/nexus.vm.crt"
+httpd_ssl_cert_key_location: "/etc/pki/tls/private/nexus.vm.key"
+httpd_default_admin_email: "admin@example.com"
 
 ldap_connections: []
 # example ldap config :

--- a/tasks/configure-Debian.yml
+++ b/tasks/configure-Debian.yml
@@ -1,0 +1,7 @@
+---
+
+httpd_package_name: "apache2"
+httpd_config_dir: "/etc/{{ httpd_package_name }}/sites-enabled"
+selinux_enabled: false
+certificate_file_dest: "/etc/ssl/certs"
+certificate_key_dest: "/etc/ssl/private"

--- a/tasks/configure-RedHat.yml
+++ b/tasks/configure-RedHat.yml
@@ -1,0 +1,7 @@
+---
+
+httpd_package_name: "httpd"
+httpd_config_dir: "/etc/{{ httpd_package_name }}/conf.d"
+selinux_enabled: true
+certificate_file_dest: "/etc/pki/tls/certs"
+certificate_key_dest: "/etc/pki/tls/private"

--- a/tasks/httpd_reverse_proxy_config.yml
+++ b/tasks/httpd_reverse_proxy_config.yml
@@ -1,24 +1,37 @@
 ---
-- name: Copy httpd vhost
-  template: src="nexus-vhost.conf" dest="/etc/httpd/conf.d"
+
+- name: Include OS specific variables.
+  include_vars: "configure-{{ ansible_os_family }}.yml"
+
+- name: Copy {{ httpd_package_name }} vhost
+  template:
+    src: "nexus-vhost.conf"
+    dest: "{{ httpd_config_dir }}"
 
 - name: Copy SSL certificate file
   copy:
     src: "{{ httpd_ssl_certificate_file }}"
-    dest: "/etc/pki/tls/certs"
+    dest: "{{ certificate_file_dest }}"
     mode: 600
+  when: httpd_copy_ssl_files
 
 - name: Copy SSL certificate key file
   copy:
     src: "{{ httpd_ssl_certificate_key_file }}"
-    dest: "/etc/pki/tls/private"
+    dest: "{{ certificate_key_dest }}"
     mode: 600
+  when: httpd_copy_ssl_files
 
 - name: Setsebool httpd_can_network_connect
   shell: 'setsebool -P httpd_can_network_connect on'
+  when: selinux_enabled
 
-- name: Restart httpd
-  shell: 'systemctl restart httpd.service'
+- name: Restart {{ httpd_package_name }}
+  systemd:
+    state: restarted
+    name: "{{ httpd_package_name }}"
 
-- name: Waiting for httpd to be restarted
-  wait_for: port=443 delay=5
+- name: Waiting for {{ httpd_package_name }} to be restarted
+  wait_for:
+    port: 443
+    delay: 5

--- a/templates/nexus-vhost.conf
+++ b/templates/nexus-vhost.conf
@@ -1,16 +1,22 @@
 <VirtualHost *:80>
-   ServerName {{ public_hostname }}
-   Redirect permanent / https://{{ public_hostname }}/
+   ServerName {{ httpd_server_name }}
+   Redirect permanent / https://{{ httpd_server_name }}/
 </VirtualHost>
 
 <VirtualHost *:443>
+  ServerName {{ httpd_server_name }}
   SSLEngine on
 
-  SSLCertificateFile /etc/pki/tls/certs/{{ httpd_ssl_certificate_file | basename }}
-  SSLCertificateKeyFile /etc/pki/tls/private/{{ httpd_ssl_certificate_key_file | basename }}
+  {% if httpd_copy_ssl_files -%}
+  SSLCertificateFile {{ certificate_file_dest }}/{{ httpd_ssl_certificate_file | basename }}
+  SSLCertificateKeyFile {{ certificate_key_dest }}/{{ httpd_ssl_certificate_key_file | basename }}
+  {% else -%}
+  SSLCertificateFile {{ httpd_ssl_cert_file_location }}
+  SSLCertificateKeyFile {{ httpd_ssl_cert_key_location }}
+  {% endif -%}
 
   ServerName {{ public_hostname }}
-  ServerAdmin admin@example.com
+  ServerAdmin {{ httpd_default_admin_email }}
 
   RewriteEngine on
   RewriteRule ^/content/([^/]+)/(.*) /repository/$2 [R=301,L]
@@ -19,6 +25,6 @@
   ProxyPassReverse / http://localhost:{{ nexus_default_port }}{{ nexus_default_context_path }}
   RequestHeader set X-Forwarded-Proto "https"
 
-  ErrorLog /var/log/httpd/{{ public_hostname }}_nexus_error.log
-  CustomLog /var/log/httpd/{{ public_hostname }}_nexus_access.log common
+  ErrorLog /var/log/{{ httpd_package_name }}/{{ public_hostname }}_nexus_error.log
+  CustomLog /var/log/{{ httpd_package_name }}/{{ public_hostname }}_nexus_access.log common
 </VirtualHost>


### PR DESCRIPTION
…16.04 OS. The main issue was that the playbook was specific to CentOS/RedHat OS family. I introduced two files which are included dynamically by the `ansible_os_family` variable in the `httpd_reverse_proxy_config.yml` file. It is determining the OS familly and then it will set the proper package name to use between `httpd` for RedHat and `apache2` for Debian.

- Added the support for using an SSL certificate which is already existing on the file system of the nexus server without the need to copy the file from this role. In our case it is usefull because we combine it with a role obtaining a LetsEncrypt SSL certificate. Therefore if the `httpd_copy_ssl_files` which is by default set to true is overriden with a value of false you have to specify the location of the private key and certificate file on the remote server, then the `nexus_vhost.conf` template will be written with the location path of these files.